### PR TITLE
feat/ED-2062-no-json-encoding-for-xml-mimetypes

### DIFF
--- a/src/gen/js/service.js.template
+++ b/src/gen/js/service.js.template
@@ -48,11 +48,13 @@ function acquireRights(op, spec, options) {
 }
 
 function makeFetchRequest(req) {
-	let fetchOptions = {
+	const isXmlRequest = req.headers['Content-Type']?.includes('/xml');
+	const body = isXmlRequest ? req.body : JSON.stringify(req.body || undefined);
+	const fetchOptions = {
 		compress: true,
 		method: (req.method || 'get').toUpperCase(),
 		headers: req.headers,
-		body: req.body ? JSON.stringify(req.body) : undefined,
+		body,
 	};
 
 	if (options.fetchOptions) {
@@ -65,7 +67,7 @@ function makeFetchRequest(req) {
 		fetchOptions.headers = headers;
 	}
 
-	let promise = fetch(req.url, fetchOptions);
+	const promise = fetch(req.url, fetchOptions);
 	return promise;
 }
 

--- a/src/gen/js/service.ts.template
+++ b/src/gen/js/service.ts.template
@@ -65,9 +65,9 @@ function acquireRights(
 }
 
 function makeFetchRequest(req: api.ServiceRequest): Promise<Response> {
-  const isXmlRequest = req.headers['Content-Type']?.includes('/xml');
-  const body = isXmlRequest ? req.body : JSON.stringify(req.body || undefined);
-  const fetchOptions = {
+	const isXmlRequest = req.headers['Content-Type']?.includes('/xml');
+	const body = isXmlRequest ? req.body : JSON.stringify(req.body || undefined);
+	const fetchOptions = {
 		compress: true,
 		method: (req.method || 'get').toUpperCase(),
 		headers: req.headers,

--- a/src/gen/js/service.ts.template
+++ b/src/gen/js/service.ts.template
@@ -71,7 +71,7 @@ function makeFetchRequest(req: api.ServiceRequest): Promise<Response> {
 		compress: true,
 		method: (req.method || 'get').toUpperCase(),
 		headers: req.headers,
-		body: req.body ? JSON.stringify(req.body) : undefined,
+		body,
 	};
 
 	if (options.fetchOptions) {

--- a/src/gen/js/service.ts.template
+++ b/src/gen/js/service.ts.template
@@ -65,7 +65,9 @@ function acquireRights(
 }
 
 function makeFetchRequest(req: api.ServiceRequest): Promise<Response> {
-	let fetchOptions: any = {
+  const isXmlRequest = req.headers['Content-Type']?.includes('/xml');
+  const body = isXmlRequest ? req.body : JSON.stringify(req.body || undefined);
+  const fetchOptions = {
 		compress: true,
 		method: (req.method || 'get').toUpperCase(),
 		headers: req.headers,


### PR DESCRIPTION
Handle requests with XML mimetypes correctly. I did a check on XML mimetype rather than on JSON mimetype to minimize the change of accidentally breaking something😅 