### PR TITLE
Add JSDoc to generated actions

### DIFF
--- a/dist/gen/js/genReduxActions.js
+++ b/dist/gen/js/genReduxActions.js
@@ -36,11 +36,22 @@ import * as ${name} from '../${name}'${support_1.ST}
 `.trim();
     return code;
 }
+function renderActionDocs(op) {
+    const lines = [
+        '/**',
+        ...(0, genOperations_1.renderDocDescription)(op, '[Action] '),
+        ...(0, genOperations_1.renderDocParams)(op),
+        `${support_1.DOC}@return {api.AsyncAction} API Action`,
+        ' */',
+    ];
+    return lines.join('\n');
+}
 function renderReduxActionBlock(spec, op, options) {
     const isTs = options.language === 'ts';
     const actionStart = (0, util_1.camelToUppercase)(op.id) + '_START';
     const actionComplete = (0, util_1.camelToUppercase)(op.id);
     const infoParam = isTs ? 'info?: any' : 'info';
+    const docs = renderActionDocs(op);
     let paramSignature = (0, genOperations_1.renderParamSignature)(op, options, `${op.group}.`);
     paramSignature += `${paramSignature ? ', ' : ''}${infoParam}`;
     const required = op.parameters.filter((param) => param.required);
@@ -60,6 +71,7 @@ export const ${actionStart} = 's/${op.group}/${actionStart}'${support_1.ST}
 export const ${actionComplete} = 's/${op.group}/${actionComplete}'${support_1.ST}
 ${isTs ? `export type ${actionComplete} = ${returnType}${support_1.ST}` : ''}
 
+${docs}
 export function ${op.id}(${paramSignature})${isTs ? ': api.AsyncAction' : ''} {
   return dispatch => {
     dispatch({ type: ${actionStart}, meta: { info, params: { ${params} } } })${support_1.ST}

--- a/dist/gen/js/genTypes.js
+++ b/dist/gen/js/genTypes.js
@@ -15,8 +15,8 @@ function genTypes(spec, options) {
 exports.default = genTypes;
 function genTypesFile(spec, options) {
     const lines = [];
-    (0, util_1.join)(lines, renderHeader());
-    (0, util_1.join)(lines, renderDefinitions(spec, options));
+    lines.push(...renderHeader());
+    lines.push(...renderDefinitions(spec, options));
     const ext = options.language === 'js' ? 'js' : 'd.ts';
     return {
         path: `${options.outDir}/types.${ext}`,
@@ -41,12 +41,12 @@ function renderDefinitions(spec, options) {
         debug('rendering type', name);
         const def = defs[name];
         if (isTs) {
-            (0, util_1.join)(typeLines, renderTsType(name, def, options));
+            typeLines.push(...renderTsType(name, def, options));
         }
-        (0, util_1.join)(docLines, renderTypeDoc(name, def));
+        docLines.push(...renderTypeDoc(name, def));
     });
     if (isTs) {
-        (0, util_1.join)(typeLines, renderTsDefaultTypes());
+        typeLines.push(...renderTsDefaultTypes());
         typeLines.push('}');
     }
     return isTs ? typeLines.concat(docLines) : docLines;
@@ -75,8 +75,8 @@ function renderTsType(name, def, options) {
     const optionalPropLines = optionalProps
         .map((prop) => renderTsTypeProp(prop, def.properties[prop], false))
         .reduce((a, b) => a.concat(b), []);
-    (0, util_1.join)(lines, requiredPropLines);
-    (0, util_1.join)(lines, optionalPropLines);
+    lines.push(...requiredPropLines);
+    lines.push(...optionalPropLines);
     lines.push('}');
     lines.push('');
     return lines;
@@ -342,7 +342,7 @@ function renderTypeDoc(name, def) {
     });
     if (propLines.length)
         lines.push(`${support_1.DOC}`);
-    (0, util_1.join)(lines, propLines);
+    lines.push(...propLines);
     lines.push(' */');
     lines.push('');
     return lines;

--- a/dist/gen/js/service.js.template
+++ b/dist/gen/js/service.js.template
@@ -48,11 +48,13 @@ function acquireRights(op, spec, options) {
 }
 
 function makeFetchRequest(req) {
-	let fetchOptions = {
+	const isXmlRequest = req.headers['Content-Type']?.includes('/xml');
+	const body = isXmlRequest ? req.body : JSON.stringify(req.body || undefined);
+	const fetchOptions = {
 		compress: true,
 		method: (req.method || 'get').toUpperCase(),
 		headers: req.headers,
-		body: req.body ? JSON.stringify(req.body) : undefined,
+		body,
 	};
 
 	if (options.fetchOptions) {
@@ -65,7 +67,7 @@ function makeFetchRequest(req) {
 		fetchOptions.headers = headers;
 	}
 
-	let promise = fetch(req.url, fetchOptions);
+	const promise = fetch(req.url, fetchOptions);
 	return promise;
 }
 

--- a/dist/gen/js/service.ts.template
+++ b/dist/gen/js/service.ts.template
@@ -65,11 +65,13 @@ function acquireRights(
 }
 
 function makeFetchRequest(req: api.ServiceRequest): Promise<Response> {
-	let fetchOptions: any = {
+	const isXmlRequest = req.headers['Content-Type']?.includes('/xml');
+	const body = isXmlRequest ? req.body : JSON.stringify(req.body || undefined);
+	const fetchOptions = {
 		compress: true,
 		method: (req.method || 'get').toUpperCase(),
 		headers: req.headers,
-		body: req.body ? JSON.stringify(req.body) : undefined,
+		body,
 	};
 
 	if (options.fetchOptions) {

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
 		"url": "https://github.com/mikestead/openapi-client/issues"
 	},
 	"engines": {
-		"node": ">=4.0.0",
-		"npm": ">=2.14.2"
+		"node": ">=18",
+		"npm": ">=8.6"
 	},
 	"main": "dist/index.js",
 	"bin": {

--- a/src/gen/js/genOperations.ts
+++ b/src/gen/js/genOperations.ts
@@ -1,6 +1,5 @@
 import {
 	writeFileSync,
-	join,
 	groupOperationsByGroupName,
 	getBestResponse,
 } from '../util';
@@ -28,17 +27,16 @@ export function genOperationGroupFiles(
 	for (let name in groups) {
 		const group = groups[name];
 		const lines = [];
-		join(lines, renderHeader(name, spec, options));
-		join(lines, renderOperationGroup(group, renderOperation, spec, options));
+		lines.push(...renderHeader(name, spec, options));
+		lines.push(...renderOperationGroup(group, renderOperation, spec, options));
 		if (options.language === 'ts') {
-			join(
-				lines,
-				renderOperationGroup(group, renderOperationParamType, spec, options)
+			lines.push(
+				...renderOperationGroup(group, renderOperationParamType, spec, options)
 			);
 		}
-		join(
-			lines,
-			renderOperationGroup(group, renderOperationInfo, spec, options)
+
+		lines.push(
+			...renderOperationGroup(group, renderOperationInfo, spec, options)
 		);
 
 		files.push({
@@ -84,16 +82,16 @@ function renderOperation(
 ): string[] {
 	debug('rendering operation', op.method, op.path);
 	const lines = [];
-	join(lines, renderOperationDocs(op));
-	join(lines, renderOperationBlock(spec, op, options));
+	lines.push(...renderOperationDocs(op));
+	lines.push(...renderOperationBlock(spec, op, options));
 	return lines;
 }
 
 function renderOperationDocs(op: ApiOperation): string[] {
 	const lines = [];
 	lines.push(`/**`);
-	join(lines, renderDocDescription(op, '[API] '));
-	join(lines, renderDocParams(op));
+	lines.push(...renderDocDescription(op, '[API] '));
+	lines.push(...renderDocParams(op));
 	lines.push(renderDocReturn(op));
 	lines.push(` */`);
 	return lines;
@@ -116,10 +114,10 @@ export function renderDocParams(op: ApiOperation) {
 	const optional = params.filter((param) => !param.required);
 
 	const lines = [];
-	join(lines, required.map(renderDocParam));
+	lines.push(...required.map(renderDocParam));
 	if (optional.length) {
 		lines.push(`${DOC}@param {object} options Optional options`);
-		join(lines, optional.map(renderDocParam));
+		lines.push(...optional.map(renderDocParam));
 	}
 	if (op.description || op.summary) {
 		lines.unshift(DOC);
@@ -163,9 +161,9 @@ function renderOperationBlock(
 	options: ClientOptions
 ): string[] {
 	const lines = [];
-	join(lines, renderOperationSignature(op, options));
-	join(lines, renderOperationObject(spec, op, options));
-	join(lines, renderRequestCall(op, options));
+	lines.push(...renderOperationSignature(op, options));
+	lines.push(...renderOperationObject(spec, op, options));
+	lines.push(...renderRequestCall(op, options));
 	lines.push('');
 	return lines;
 }
@@ -304,7 +302,7 @@ function renderOperationObject(
 	const names = Object.keys(parameters);
 	const last = names.length - 1;
 	names.forEach((name, i) => {
-		join(lines, renderParamGroup(name, parameters[name], i === last));
+		lines.push(...renderParamGroup(name, parameters[name], i === last));
 	});
 
 	if (lines.length) {
@@ -354,7 +352,7 @@ function renderParamGroup(
 ): string[] {
 	const lines = [];
 	lines.push(`${SP.repeat(2)}${name}: {`);
-	join(lines, groupLines.join(',\n').split('\n'));
+	lines.push(...groupLines.join(',\n').split('\n'));
 	lines.push(`${SP.repeat(2)}}${last ? '' : ','}`);
 	return lines;
 }
@@ -417,7 +415,7 @@ function renderOperationInfo(
 	if (op.security && op.security.length) {
 		const secLines = renderSecurityInfo(op.security);
 		lines.push(`${SP}security: [`);
-		join(lines, secLines);
+		lines.push(...secLines);
 		lines.push(`${SP}]`);
 	}
 	lines.push(`}${ST}`);

--- a/src/gen/js/genOperations.ts
+++ b/src/gen/js/genOperations.ts
@@ -92,17 +92,18 @@ function renderOperation(
 function renderOperationDocs(op: ApiOperation): string[] {
 	const lines = [];
 	lines.push(`/**`);
-	join(lines, renderDocDescription(op));
+	join(lines, renderDocDescription(op, '[API] '));
 	join(lines, renderDocParams(op));
 	lines.push(renderDocReturn(op));
 	lines.push(` */`);
 	return lines;
 }
 
-export function renderDocDescription(op: ApiOperation) {
+/** Renders description with optional prefix */
+export function renderDocDescription(op: ApiOperation, prefix?: string) {
 	const desc = op.description || op.summary;
 	return desc
-		? `${DOC}${desc.trim()}`.replace(/\n/g, `\n${DOC}`).split('\n')
+		? `${DOC}${prefix}${desc.trim()}`.replace(/\n/g, `\n${DOC}`).split('\n')
 		: [];
 }
 

--- a/src/gen/js/genOperations.ts
+++ b/src/gen/js/genOperations.ts
@@ -94,18 +94,19 @@ function renderOperationDocs(op: ApiOperation): string[] {
 	lines.push(`/**`);
 	join(lines, renderDocDescription(op));
 	join(lines, renderDocParams(op));
+	lines.push(renderDocReturn(op));
 	lines.push(` */`);
 	return lines;
 }
 
-function renderDocDescription(op: ApiOperation) {
+export function renderDocDescription(op: ApiOperation) {
 	const desc = op.description || op.summary;
 	return desc
 		? `${DOC}${desc.trim()}`.replace(/\n/g, `\n${DOC}`).split('\n')
 		: [];
 }
 
-function renderDocParams(op: ApiOperation) {
+export function renderDocParams(op: ApiOperation) {
 	const params = op.parameters;
 	if (!params.length) return [];
 
@@ -121,7 +122,6 @@ function renderDocParams(op: ApiOperation) {
 	if (op.description || op.summary) {
 		lines.unshift(DOC);
 	}
-	lines.push(renderDocReturn(op));
 	return lines;
 }
 

--- a/src/gen/js/genOperations.ts
+++ b/src/gen/js/genOperations.ts
@@ -107,6 +107,7 @@ export function renderDocDescription(op: ApiOperation, prefix?: string) {
 		: [];
 }
 
+/** Renders jsdoc \@param annotations */
 export function renderDocParams(op: ApiOperation) {
 	const params = op.parameters;
 	if (!params.length) return [];
@@ -126,7 +127,8 @@ export function renderDocParams(op: ApiOperation) {
 	return lines;
 }
 
-function renderDocParam(param) {
+/** Renders a single jsdoc \@param annotation */
+function renderDocParam(param: ApiOperationParam) {
 	let name = getParamName(param.name);
 	let description = (param.description || '')
 		.trim()
@@ -238,6 +240,7 @@ function getParamSignature(
 	return signature;
 }
 
+/** Returns capitalized version of name */
 export function getParamName(name: string): string {
 	const parts = name.split(/[_-\s!@\#$%^&*\(\)]/g).filter((n) => !!n);
 	const reduced = parts.reduce(

--- a/src/gen/js/genReduxActions.ts
+++ b/src/gen/js/genReduxActions.ts
@@ -65,7 +65,7 @@ import * as ${name} from '../${name}'${ST}
 function renderDoc(op: ApiOperation): string {
 	const lines = [
 		'/**',
-		...renderDocDescription(op),
+		...renderDocDescription(op, '[Action] '),
 		...renderDocParams(op),
 		`${DOC}@return {api.AsyncAction} API Action`,
 		' */',

--- a/src/gen/js/genReduxActions.ts
+++ b/src/gen/js/genReduxActions.ts
@@ -62,7 +62,7 @@ import * as ${name} from '../${name}'${ST}
 	return code;
 }
 
-function renderDoc(op: ApiOperation): string {
+function renderActionDocs(op: ApiOperation): string {
 	const lines = [
 		'/**',
 		...renderDocDescription(op, '[Action] '),
@@ -82,7 +82,7 @@ function renderReduxActionBlock(
 	const actionStart = camelToUppercase(op.id) + '_START';
 	const actionComplete = camelToUppercase(op.id);
 	const infoParam = isTs ? 'info?: any' : 'info';
-	const docs = renderDoc(op);
+	const docs = renderActionDocs(op);
 	let paramSignature = renderParamSignature(op, options, `${op.group}.`);
 	paramSignature += `${paramSignature ? ', ' : ''}${infoParam}`;
 	const required = op.parameters.filter((param) => param.required);

--- a/src/gen/js/genTypes.ts
+++ b/src/gen/js/genTypes.ts
@@ -1,4 +1,4 @@
-import { writeFileSync, join } from '../util';
+import { writeFileSync } from '../util';
 import { DOC, SP, ST, getDocType, getTSParamType } from './support';
 import Debug from 'debug';
 
@@ -11,8 +11,8 @@ export default function genTypes(spec: ApiSpec, options: ClientOptions) {
 
 export function genTypesFile(spec: ApiSpec, options: ClientOptions) {
 	const lines = [];
-	join(lines, renderHeader());
-	join(lines, renderDefinitions(spec, options));
+	lines.push(...renderHeader());
+	lines.push(...renderDefinitions(spec, options));
 	const ext = options.language === 'js' ? 'js' : 'd.ts';
 	return {
 		path: `${options.outDir}/types.${ext}`,
@@ -38,12 +38,12 @@ function renderDefinitions(spec: ApiSpec, options: ClientOptions): string[] {
 		debug('rendering type', name);
 		const def = defs[name];
 		if (isTs) {
-			join(typeLines, renderTsType(name, def, options));
+			typeLines.push(...renderTsType(name, def, options));
 		}
-		join(docLines, renderTypeDoc(name, def));
+		docLines.push(...renderTypeDoc(name, def));
 	});
 	if (isTs) {
-		join(typeLines, renderTsDefaultTypes());
+		typeLines.push(...renderTsDefaultTypes());
 		typeLines.push('}');
 	}
 	return isTs ? typeLines.concat(docLines) : docLines;
@@ -77,8 +77,8 @@ function renderTsType(name, def, options) {
 		.map((prop) => renderTsTypeProp(prop, def.properties[prop], false))
 		.reduce((a, b) => a.concat(b), []);
 
-	join(lines, requiredPropLines);
-	join(lines, optionalPropLines);
+	lines.push(...requiredPropLines);
+	lines.push(...optionalPropLines);
 	lines.push('}');
 	lines.push('');
 	return lines;
@@ -356,7 +356,7 @@ function renderTypeDoc(name: string, def: any): string[] {
 		})}} ${prop} ${description}`;
 	});
 	if (propLines.length) lines.push(`${DOC}`);
-	join(lines, propLines);
+	lines.push(...propLines);
 	lines.push(' */');
 	lines.push('');
 	return lines;


### PR DESCRIPTION
- Adds JSDoc to generated actions
  - Action docs are otherwise identical with api operation docs except for return type annotation
- Prefixes operation description with either `[API] ` or `[Action] `
- Replaces `join(lines, foo)` with `lines.push(...foo)`