### PR TITLE
fix: Change how fetchOptions is updated

### DIFF
--- a/dist/gen/js/service.js.template
+++ b/dist/gen/js/service.js.template
@@ -63,8 +63,7 @@ function makeFetchRequest(req) {
 			? Object.assign(fetchOptions.headers, opts.headers)
 			: fetchOptions.headers;
 
-		fetchOptions = Object.assign({}, fetchOptions, opts);
-		fetchOptions.headers = headers;
+		Object.assign(fetchOptions, opts, { headers });
 	}
 
 	const promise = fetch(req.url, fetchOptions);

--- a/dist/gen/js/service.ts.template
+++ b/dist/gen/js/service.ts.template
@@ -80,8 +80,7 @@ function makeFetchRequest(req: api.ServiceRequest): Promise<Response> {
 			? Object.assign(fetchOptions.headers, opts.headers)
 			: fetchOptions.headers;
 
-		fetchOptions = Object.assign({}, fetchOptions, opts);
-		fetchOptions.headers = headers;
+		Object.assign(fetchOptions, opts, { headers });
 	}
 
 	let promise = fetch(req.url, fetchOptions);

--- a/src/gen/js/service.js.template
+++ b/src/gen/js/service.js.template
@@ -63,8 +63,7 @@ function makeFetchRequest(req) {
 			? Object.assign(fetchOptions.headers, opts.headers)
 			: fetchOptions.headers;
 
-		fetchOptions = Object.assign({}, fetchOptions, opts);
-		fetchOptions.headers = headers;
+		Object.assign(fetchOptions, opts, { headers });
 	}
 
 	const promise = fetch(req.url, fetchOptions);

--- a/src/gen/js/service.ts.template
+++ b/src/gen/js/service.ts.template
@@ -80,11 +80,10 @@ function makeFetchRequest(req: api.ServiceRequest): Promise<Response> {
 			? Object.assign(fetchOptions.headers, opts.headers)
 			: fetchOptions.headers;
 
-		fetchOptions = Object.assign({}, fetchOptions, opts);
-		fetchOptions.headers = headers;
+		Object.assign(fetchOptions, opts, { headers });
 	}
 
-	let promise = fetch(req.url, fetchOptions);
+	const promise = fetch(req.url, fetchOptions);
 	return promise;
 }
 


### PR DESCRIPTION
Fixes bug introduced in 1891da9ef7f3272b136da2b44e9598a299a31ff5 and b60083e98ccc9d8b221e72ecea5d41be4880e180.

Left `fetchOptions` as `const` but changed how it's modified.