### PR TITLE
feat: [ED-1885] add openapi 3.0 support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
-dist/** -diff
+dist/** -diff linguist-generated
 package-lock.json -diff
 yarn.lock -diff

--- a/dist/gen/js/service.ts.template
+++ b/dist/gen/js/service.ts.template
@@ -83,7 +83,7 @@ function makeFetchRequest(req: api.ServiceRequest): Promise<Response> {
 		Object.assign(fetchOptions, opts, { headers });
 	}
 
-	let promise = fetch(req.url, fetchOptions);
+	const promise = fetch(req.url, fetchOptions);
 	return promise;
 }
 

--- a/dist/gen/js/support.js
+++ b/dist/gen/js/support.js
@@ -41,6 +41,10 @@ function getDocType(param, details) {
         const type = param.$ref.split('/').pop();
         return `module:types.${type}`;
     }
+    else if (Array.isArray(param.allOf) && param.allOf.length === 1) {
+        // Handle single-element allOf (NestJS Swagger wraps $ref in allOf)
+        return getDocType(param.allOf[0], details);
+    }
     else if (param.schema) {
         return getDocType(param.schema, details);
     }
@@ -69,84 +73,105 @@ function getDocType(param, details) {
 }
 exports.getDocType = getDocType;
 const primitives = new Set(['string', 'number', 'boolean']);
-function getTSParamType(param, details, inTypesModule, indent = exports.SP) {
+function getTSParamType(param, details, inTypesModule, indent = exports.SP, visitedSchemas = new Set()) {
+    // Detect circular references by tracking visited schema objects
+    if (param && typeof param === 'object') {
+        if (visitedSchemas.has(param)) {
+            return 'any';
+        }
+        visitedSchemas = new Set(visitedSchemas);
+        visitedSchemas.add(param);
+    }
     if (!param) {
         console.warn((0, chalk_1.yellow)('Missing type information.'), details);
         return 'any';
     }
-    else if (param.enum) {
+    // Handle nullable wrapper
+    const nullable = param.nullable === true;
+    const wrapNullable = (type) => (nullable ? `${type} | null` : type);
+    if (param.enum) {
         if (!param.type || param.type === 'string')
-            return `'${param.enum.join(`'|'`)}'`;
+            return wrapNullable(`'${param.enum.join(`'|'`)}'`);
         else if (param.type === 'number')
-            return `${param.enum.join(`|`)}`;
+            return wrapNullable(`${param.enum.join(`|`)}`);
     }
     if (param.$ref) {
         const type = param.$ref.split('/').pop();
-        return inTypesModule ? type : `api.${type}`;
+        return wrapNullable(inTypesModule ? type : `api.${type}`);
     }
     else if (param.schema) {
-        return getTSParamType(param.schema, details, inTypesModule, indent);
+        // Pass nullable to nested schema if not already set
+        const nestedParam = param.nullable && !param.schema.nullable
+            ? { ...param.schema, nullable: true }
+            : param.schema;
+        return getTSParamType(nestedParam, details, inTypesModule, indent, visitedSchemas);
     }
     else if (param.type === 'array') {
         if (!param.items) {
             console.warn((0, chalk_1.yellow)(`Missing type information for "${details.prop}":`), param);
-            return 'any[]';
+            return wrapNullable('any[]');
         }
         if (param.items.type) {
             if (param.items.enum) {
-                return `(${getTSParamType(param.items, details, inTypesModule, indent)})[]`;
+                return wrapNullable(`(${getTSParamType(param.items, details, inTypesModule, indent, visitedSchemas)})[]`);
             }
             else {
-                return `${getTSParamType(param.items, details, inTypesModule, indent)}[]`;
+                return wrapNullable(`${getTSParamType(param.items, details, inTypesModule, indent, visitedSchemas)}[]`);
             }
         }
         else if (param.items.$ref) {
             const type = param.items.$ref.split('/').pop();
-            return inTypesModule ? `${type}[]` : `api.${type}[]`;
+            return wrapNullable(inTypesModule ? `${type}[]` : `api.${type}[]`);
         }
-        else if (param.items.oneOf) {
-            return `(${param.items.oneOf
-                .map((schema) => getTSParamType(schema, details, inTypesModule, indent))
-                .map((type) => `${type}`)
-                .join(' | ')})[]`;
+        else if (param.items.oneOf || param.items.anyOf) {
+            const schemas = param.items.oneOf || param.items.anyOf;
+            return wrapNullable(`(${schemas
+                .map((schema) => getTSParamType(schema, details, inTypesModule, indent, visitedSchemas))
+                .join(' | ')})[]`);
         }
         else {
             console.warn((0, chalk_1.yellow)(`Missing type information for "${details.prop}":`), param);
-            return 'any[]';
+            return wrapNullable('any[]');
         }
     }
     else if (param.type === 'object') {
         if (param.additionalProperties) {
             const extraProps = param.additionalProperties;
-            return `{[key: string]: ${getTSParamType(extraProps, details, inTypesModule, indent)}}`;
+            return wrapNullable(`{[key: string]: ${getTSParamType(extraProps, details, inTypesModule, indent, visitedSchemas)}}`);
         }
         if (param.properties) {
             const props = Object.keys(param.properties);
-            return (0, common_tags_1.commaLists) `{
-  ${indent}${props.map((key) => `${getKey(key, param)}: ${getTSParamType(param.properties[key], { prop: `${details.prop}.${key}` }, inTypesModule, `${indent}${exports.SP}`)}`)}
-${indent}}`;
+            return wrapNullable((0, common_tags_1.commaLists) `{
+  ${indent}${props.map((key) => `${getKey(key, param)}: ${getTSParamType(param.properties[key], { prop: `${details.prop}.${key}` }, inTypesModule, `${indent}${exports.SP}`, visitedSchemas)}`)}
+${indent}}`);
         }
         console.warn((0, chalk_1.yellow)(`Missing type information for "${details.prop}":`), param);
-        return 'any';
+        return wrapNullable('any');
     }
-    else if (Array.isArray(param.oneOf)) {
-        return param.oneOf
-            .map((schema) => getTSParamType(schema, details, inTypesModule, indent))
-            .join(' | ');
+    else if (Array.isArray(param.oneOf) || Array.isArray(param.anyOf)) {
+        const schemas = param.oneOf || param.anyOf;
+        return wrapNullable(schemas
+            .map((schema) => getTSParamType(schema, details, inTypesModule, indent, visitedSchemas))
+            .join(' | '));
+    }
+    else if (Array.isArray(param.allOf) && param.allOf.length === 1) {
+        // Handle single-element allOf (NestJS Swagger wraps $ref in allOf for some reason)
+        return getTSParamType(param.allOf[0], details, inTypesModule, indent, visitedSchemas);
     }
     else if (param.type === 'integer') {
-        return 'number';
+        return wrapNullable('number');
     }
     else if (param.type === 'file') {
-        return 'File';
+        return wrapNullable('File');
     }
     else if (primitives.has(param.type)) {
-        return param.type;
+        return wrapNullable(param.type);
     }
     else if (Array.isArray(param.type) &&
         param.type.length === 2 &&
         param.type[1] === 'null') {
-        return getTSParamType({ ...param, type: param.type[0] }, details, inTypesModule, indent);
+        // OpenAPI 3.1 / JSON Schema style: type: ['string', 'null']
+        return getTSParamType({ ...param, type: param.type[0], nullable: true }, details, inTypesModule, indent, visitedSchemas);
     }
     else {
         // No body returned.
@@ -154,7 +179,7 @@ ${indent}}`;
             return 'undefined';
         }
         console.warn((0, chalk_1.yellow)(`Missing type information for "${details.prop}":`), param);
-        return 'any';
+        return wrapNullable('any');
     }
 }
 exports.getTSParamType = getTSParamType;

--- a/dist/spec/operations.js
+++ b/dist/spec/operations.js
@@ -42,6 +42,24 @@ function getPathOperation(method, pathInfo, spec) {
         op.id = op.id.replace(/[\/}\-]/g, '');
     }
     inheritPathParams(op, spec, pathInfo);
+    // Handle OpenAPI 3.0 requestBody -> convert to body parameter
+    if (op.requestBody) {
+        const content = op.requestBody.content;
+        const contentType = Object.keys(content || {})[0] || 'application/json';
+        const mediaType = content?.[contentType];
+        if (mediaType?.schema) {
+            // Use x-codegen-request-body-name extension if available, otherwise default to 'body'
+            const bodyName = op.requestBody['x-codegen-request-body-name'] || 'body';
+            op.parameters.push({
+                name: bodyName,
+                in: 'body',
+                required: op.requestBody.required === true,
+                schema: mediaType.schema,
+                description: op.requestBody.description || '',
+            });
+        }
+        delete op.requestBody;
+    }
     op.group = getOperationGroupName(op);
     delete op.operationId;
     op.responses = getOperationResponses(op);
@@ -60,7 +78,7 @@ function getPathOperation(method, pathInfo, spec) {
     return op;
 }
 function getOperationGroupName(op) {
-    let name = op.tags && op.tags.length ? op.tags[0] : 'default';
+    let name = op.tags && op.tags.length ? op.tags[0] : 'other';
     name = name.replace(/[^$_a-z0-9]+/gi, '');
     return name.replace(/^[0-9]+/m, '');
 }
@@ -68,6 +86,14 @@ function getOperationResponses(op) {
     return Object.keys(op.responses || {}).map((code) => {
         const info = op.responses[code];
         info.code = code;
+        // Handle OpenAPI 3.0 response content -> schema conversion
+        if (info.content && !info.schema) {
+            const contentType = Object.keys(info.content)[0] || 'application/json';
+            const mediaType = info.content[contentType];
+            if (mediaType?.schema) {
+                info.schema = mediaType.schema;
+            }
+        }
         return info;
     });
 }

--- a/dist/spec/spec.js
+++ b/dist/spec/spec.js
@@ -26,6 +26,10 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.expandRefs = exports.resolveSpec = void 0;
 const YAML = __importStar(require("js-yaml"));
 require("cross-fetch/polyfill");
+/** Type guard to check if spec is OpenAPI 3.x */
+function isOpenApi3(spec) {
+    return 'openapi' in spec;
+}
 function resolveSpec(src, options, authKey) {
     if (!options)
         options = {};
@@ -59,24 +63,63 @@ function parseFileContents(contents, path) {
     return /.ya?ml$/i.test(path) ? YAML.load(contents) : JSON.parse(contents);
 }
 function formatSpec(spec, src, options) {
-    if (!spec.basePath)
-        spec.basePath = '';
-    else if (spec.basePath.endsWith('/'))
-        spec.basePath = spec.basePath.slice(0, -1);
+    // Use any for the result since we're building up a Swagger 2.0-like internal format
+    const s = spec;
+    // Handle OpenAPI 3.0 -> internal format conversion
+    if (isOpenApi3(spec)) {
+        // servers[] -> host/basePath/schemes
+        if (spec.servers && spec.servers.length > 0) {
+            const serverUrl = spec.servers[0].url;
+            try {
+                // Handle absolute URLs
+                if (serverUrl.startsWith('http://') || serverUrl.startsWith('https://')) {
+                    const url = new URL(serverUrl);
+                    if (!s.host)
+                        s.host = url.host;
+                    if (!s.basePath)
+                        s.basePath = url.pathname;
+                    if (!s.schemes || !s.schemes.length) {
+                        s.schemes = [url.protocol.slice(0, -1)]; // remove trailing ':'
+                    }
+                }
+                else {
+                    // Relative URL (e.g., '/v2')
+                    if (!s.basePath)
+                        s.basePath = serverUrl;
+                }
+            }
+            catch {
+                // If URL parsing fails, treat as relative path
+                if (!s.basePath)
+                    s.basePath = serverUrl;
+            }
+        }
+        // components.schemas -> definitions
+        if (spec.components?.schemas && !s.definitions) {
+            s.definitions = spec.components.schemas;
+        }
+        // components.securitySchemes -> securityDefinitions
+        if (spec.components?.securitySchemes && !s.securityDefinitions) {
+            s.securityDefinitions = spec.components.securitySchemes;
+        }
+    }
+    if (!s.basePath)
+        s.basePath = '';
+    else if (s.basePath.endsWith('/'))
+        s.basePath = s.basePath.slice(0, -1);
     if (src && /^https?:\/\//im.test(src)) {
         const parts = src.split('/');
-        if (!spec.host)
-            spec.host = parts[2];
-        if (!spec.schemes || !spec.schemes.length)
-            spec.schemes = [parts[0].slice(0, -1)];
+        if (!s.host)
+            s.host = parts[2];
+        if (!s.schemes || !s.schemes.length)
+            s.schemes = [parts[0].slice(0, -1)];
     }
     else {
-        if (!spec.host)
-            spec.host = 'localhost';
-        if (!spec.schemes || !spec.schemes.length)
-            spec.schemes = ['http'];
+        if (!s.host)
+            s.host = 'localhost';
+        if (!s.schemes || !s.schemes.length)
+            s.schemes = ['http'];
     }
-    const s = spec;
     if (!s.produces || !s.produces.length) {
         s.accepts = ['application/json']; // give sensible default
     }
@@ -89,10 +132,12 @@ function formatSpec(spec, src, options) {
         s.contentTypes = s.consumes;
     delete s.consumes;
     delete s.produces;
-    return expandRefs(spec, spec, options);
+    return expandRefs(s, s, options);
 }
 /**
  * Recursively expand internal references in the form `#/path/to/object`.
+ * Only expands refs to #/components/parameters/ - schemas ($refs to #/components/schemas/)
+ * are preserved for the type generator to handle.
  *
  * @param {object} data the object to search for and update refs
  * @param {object} lookup the object to clone refs from
@@ -110,9 +155,13 @@ function expandRefs(data, lookup, options) {
             return data;
         if (data.$ref &&
             !(options.ignoreRefType && data.$ref.startsWith(options.ignoreRefType))) {
-            const resolved = expandRef(data.$ref, lookup);
-            delete data.$ref;
-            data = Object.assign({}, resolved, data);
+            // Only expand refs that are NOT schema refs (schema refs are handled by type generator)
+            // This prevents circular reference issues when schemas reference each other
+            if (!data.$ref.startsWith('#/components/schemas/') && !data.$ref.startsWith('#/definitions/')) {
+                const resolved = expandRef(data.$ref, lookup);
+                delete data.$ref;
+                data = Object.assign({}, resolved, data);
+            }
         }
         dataCache.add(data);
         for (let name in data) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
 				"cross-fetch": "^3.1.5",
 				"js-yaml": "^4.1.0",
 				"mkdirp": "^1.0.4",
-				"mustache": "^4.2.0"
+				"mustache": "^4.2.0",
+				"openapi-types": "^12.1.3"
 			},
 			"bin": {
 				"openapi": "dist/cli.js"
@@ -4889,6 +4890,12 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/openapi-types": {
+			"version": "12.1.3",
+			"resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+			"integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+			"license": "MIT"
+		},
 		"node_modules/optionator": {
 			"version": "0.8.3",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
@@ -9549,6 +9556,11 @@
 			"requires": {
 				"mimic-fn": "^2.1.0"
 			}
+		},
+		"openapi-types": {
+			"version": "12.1.3",
+			"resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+			"integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw=="
 		},
 		"optionator": {
 			"version": "0.8.3",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
 		"cross-fetch": "^3.1.5",
 		"js-yaml": "^4.1.0",
 		"mkdirp": "^1.0.4",
-		"mustache": "^4.2.0"
+		"mustache": "^4.2.0",
+		"openapi-types": "^12.1.3"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.17.5",

--- a/src/gen/js/support.ts
+++ b/src/gen/js/support.ts
@@ -79,6 +79,7 @@ export function getTSParamType(
 	// Detect circular references by tracking visited schema objects
 	if (param && typeof param === 'object') {
 		if (visitedSchemas.has(param)) {
+			console.warn(yellow(`Circular reference detected for "${details.prop}".`));
 			return 'any';
 		}
 		visitedSchemas = new Set(visitedSchemas);

--- a/src/gen/js/support.ts
+++ b/src/gen/js/support.ts
@@ -41,6 +41,9 @@ export function getDocType(
 	} else if (param.$ref) {
 		const type = param.$ref.split('/').pop();
 		return `module:types.${type}`;
+	} else if (Array.isArray(param.allOf) && param.allOf.length === 1) {
+		// Handle single-element allOf (NestJS Swagger wraps $ref in allOf)
+		return getDocType(param.allOf[0], details);
 	} else if (param.schema) {
 		return getDocType(param.schema, details);
 	} else if (param.type === 'array') {
@@ -70,109 +73,138 @@ export function getTSParamType(
 	param: any,
 	details: { prop: string },
 	inTypesModule?: boolean,
-	indent = SP
+	indent = SP,
+	visitedSchemas = new Set<object>()
 ): string {
+	// Detect circular references by tracking visited schema objects
+	if (param && typeof param === 'object') {
+		if (visitedSchemas.has(param)) {
+			return 'any';
+		}
+		visitedSchemas = new Set(visitedSchemas);
+		visitedSchemas.add(param);
+	}
 	if (!param) {
 		console.warn(yellow('Missing type information.'), details);
 		return 'any';
-	} else if (param.enum) {
+	}
+
+	// Handle nullable wrapper
+	const nullable = param.nullable === true;
+	const wrapNullable = (type: string) => (nullable ? `${type} | null` : type);
+
+	if (param.enum) {
 		if (!param.type || param.type === 'string')
-			return `'${param.enum.join(`'|'`)}'`;
-		else if (param.type === 'number') return `${param.enum.join(`|`)}`;
+			return wrapNullable(`'${param.enum.join(`'|'`)}'`);
+		else if (param.type === 'number') return wrapNullable(`${param.enum.join(`|`)}`);
 	}
 	if (param.$ref) {
 		const type = param.$ref.split('/').pop();
-		return inTypesModule ? type : `api.${type}`;
+		return wrapNullable(inTypesModule ? type : `api.${type}`);
 	} else if (param.schema) {
-		return getTSParamType(param.schema, details, inTypesModule, indent);
+		// Pass nullable to nested schema if not already set
+		const nestedParam = param.nullable && !param.schema.nullable
+			? { ...param.schema, nullable: true }
+			: param.schema;
+		return getTSParamType(nestedParam, details, inTypesModule, indent, visitedSchemas);
 	} else if (param.type === 'array') {
 		if (!param.items) {
 			console.warn(
 				yellow(`Missing type information for "${details.prop}":`),
 				param
 			);
-			return 'any[]';
+			return wrapNullable('any[]');
 		}
 		if (param.items.type) {
 			if (param.items.enum) {
-				return `(${getTSParamType(
+				return wrapNullable(`(${getTSParamType(
 					param.items,
 					details,
 					inTypesModule,
-					indent
-				)})[]`;
+					indent,
+					visitedSchemas
+				)})[]`);
 			} else {
-				return `${getTSParamType(
+				return wrapNullable(`${getTSParamType(
 					param.items,
 					details,
 					inTypesModule,
-					indent
-				)}[]`;
+					indent,
+					visitedSchemas
+				)}[]`);
 			}
 		} else if (param.items.$ref) {
 			const type = param.items.$ref.split('/').pop();
-			return inTypesModule ? `${type}[]` : `api.${type}[]`;
-		} else if (param.items.oneOf) {
-			return `(${param.items.oneOf
-				.map((schema) => getTSParamType(schema, details, inTypesModule, indent))
-				.map((type) => `${type}`)
-				.join(' | ')})[]`;
+			return wrapNullable(inTypesModule ? `${type}[]` : `api.${type}[]`);
+		} else if (param.items.oneOf || param.items.anyOf) {
+			const schemas = param.items.oneOf || param.items.anyOf;
+			return wrapNullable(`(${schemas
+				.map((schema) => getTSParamType(schema, details, inTypesModule, indent, visitedSchemas))
+				.join(' | ')})[]`);
 		} else {
 			console.warn(
 				yellow(`Missing type information for "${details.prop}":`),
 				param
 			);
-			return 'any[]';
+			return wrapNullable('any[]');
 		}
 	} else if (param.type === 'object') {
 		if (param.additionalProperties) {
 			const extraProps = param.additionalProperties;
-			return `{[key: string]: ${getTSParamType(
+			return wrapNullable(`{[key: string]: ${getTSParamType(
 				extraProps,
 				details,
 				inTypesModule,
-				indent
-			)}}`;
+				indent,
+				visitedSchemas
+			)}}`);
 		}
 		if (param.properties) {
 			const props = Object.keys(param.properties);
-			return commaLists`{
+			return wrapNullable(commaLists`{
   ${indent}${props.map(
 				(key) =>
 					`${getKey(key, param)}: ${getTSParamType(
 						param.properties[key],
 						{ prop: `${details.prop}.${key}` },
 						inTypesModule,
-						`${indent}${SP}`
+						`${indent}${SP}`,
+						visitedSchemas
 					)}`
 			)}
-${indent}}`;
+${indent}}`);
 		}
 		console.warn(
 			yellow(`Missing type information for "${details.prop}":`),
 			param
 		);
-		return 'any';
-	} else if (Array.isArray(param.oneOf)) {
-		return param.oneOf
-			.map((schema) => getTSParamType(schema, details, inTypesModule, indent))
-			.join(' | ');
+		return wrapNullable('any');
+	} else if (Array.isArray(param.oneOf) || Array.isArray(param.anyOf)) {
+		const schemas = param.oneOf || param.anyOf;
+		return wrapNullable(schemas
+			.map((schema) => getTSParamType(schema, details, inTypesModule, indent, visitedSchemas))
+			.join(' | '));
+	} else if (Array.isArray(param.allOf) && param.allOf.length === 1) {
+		// Handle single-element allOf (NestJS Swagger wraps $ref in allOf for some reason)
+		return getTSParamType(param.allOf[0], details, inTypesModule, indent, visitedSchemas);
 	} else if (param.type === 'integer') {
-		return 'number';
+		return wrapNullable('number');
 	} else if (param.type === 'file') {
-		return 'File';
+		return wrapNullable('File');
 	} else if (primitives.has(param.type)) {
-		return param.type;
+		return wrapNullable(param.type);
 	} else if (
 		Array.isArray(param.type) &&
 		param.type.length === 2 &&
 		param.type[1] === 'null'
 	) {
+		// OpenAPI 3.1 / JSON Schema style: type: ['string', 'null']
 		return getTSParamType(
-			{ ...param, type: param.type[0] },
+			{ ...param, type: param.type[0], nullable: true },
 			details,
 			inTypesModule,
-			indent
+			indent,
+			visitedSchemas
 		);
 	} else {
 		// No body returned.
@@ -183,7 +215,7 @@ ${indent}}`;
 			yellow(`Missing type information for "${details.prop}":`),
 			param
 		);
-		return 'any';
+		return wrapNullable('any');
 	}
 }
 

--- a/src/spec/operations.ts
+++ b/src/spec/operations.ts
@@ -62,6 +62,25 @@ function getPathOperation(
 
 	inheritPathParams(op, spec, pathInfo);
 
+	// Handle OpenAPI 3.0 requestBody -> convert to body parameter
+	if (op.requestBody) {
+		const content = op.requestBody.content;
+		const contentType = Object.keys(content || {})[0] || 'application/json';
+		const mediaType = content?.[contentType];
+		if (mediaType?.schema) {
+			// Use x-codegen-request-body-name extension if available, otherwise default to 'body'
+			const bodyName = op.requestBody['x-codegen-request-body-name'] || 'body';
+			op.parameters.push({
+				name: bodyName,
+				in: 'body',
+				required: op.requestBody.required === true, // Only positional when explicitly required
+				schema: mediaType.schema,
+				description: op.requestBody.description || '',
+			});
+		}
+		delete op.requestBody;
+	}
+
 	op.group = getOperationGroupName(op);
 	delete op.operationId;
 	op.responses = getOperationResponses(op);
@@ -80,7 +99,7 @@ function getPathOperation(
 }
 
 function getOperationGroupName(op: any): string {
-	let name = op.tags && op.tags.length ? op.tags[0] : 'default';
+	let name = op.tags && op.tags.length ? op.tags[0] : 'other';
 	name = name.replace(/[^$_a-z0-9]+/gi, '');
 	return name.replace(/^[0-9]+/m, '');
 }
@@ -89,6 +108,15 @@ function getOperationResponses(op: any): ApiOperationResponse[] {
 	return Object.keys(op.responses || {}).map((code) => {
 		const info = op.responses[code];
 		info.code = code;
+		// Handle OpenAPI 3.0 response content -> schema conversion
+		if (info.content && !info.schema) {
+			const contentType =
+				Object.keys(info.content)[0] || 'application/json';
+			const mediaType = info.content[contentType];
+			if (mediaType?.schema) {
+				info.schema = mediaType.schema;
+			}
+		}
 		return info;
 	});
 }

--- a/src/spec/spec.ts
+++ b/src/spec/spec.ts
@@ -1,5 +1,11 @@
 import * as YAML from 'js-yaml';
 import 'cross-fetch/polyfill';
+import { OpenAPI, OpenAPIV3 } from 'openapi-types';
+
+/** Type guard to check if spec is OpenAPI 3.x */
+function isOpenApi3(spec: OpenAPI.Document): spec is OpenAPIV3.Document {
+	return 'openapi' in spec;
+}
 
 export interface SpecOptions {
 	/**
@@ -9,7 +15,7 @@ export interface SpecOptions {
 }
 
 export function resolveSpec(
-	src: string | Object,
+	src: string | OpenAPI.Document,
 	options?: SpecOptions,
 	authKey?: string
 ): Promise<ApiSpec> {
@@ -19,11 +25,11 @@ export function resolveSpec(
 			formatSpec(spec, src, options)
 		);
 	} else {
-		return Promise.resolve(formatSpec(<ApiSpec>src, null, options));
+		return Promise.resolve(formatSpec(src, null, options));
 	}
 }
 
-function loadJson(src: string, authKey: string): Promise<ApiSpec> {
+function loadJson(src: string, authKey: string): Promise<OpenAPI.Document> {
 	if (/^https?:\/\//im.test(src)) {
 		const headers = new Headers();
 		if (authKey) headers.append('Open-Api-Spec-Auth-Key', authKey);
@@ -49,25 +55,62 @@ function parseFileContents(contents: string, path: string): any {
 }
 
 function formatSpec(
-	spec: ApiSpec,
+	spec: OpenAPI.Document,
 	src?: string,
 	options?: SpecOptions
 ): ApiSpec {
-	if (!spec.basePath) spec.basePath = '';
-	else if (spec.basePath.endsWith('/'))
-		spec.basePath = spec.basePath.slice(0, -1);
+	// Use any for the result since we're building up a Swagger 2.0-like internal format
+	const s: any = spec;
+
+	// Handle OpenAPI 3.0 -> internal format conversion
+	if (isOpenApi3(spec)) {
+		// servers[] -> host/basePath/schemes
+		if (spec.servers && spec.servers.length > 0) {
+			const serverUrl = spec.servers[0].url;
+			try {
+				// Handle absolute URLs
+				if (serverUrl.startsWith('http://') || serverUrl.startsWith('https://')) {
+					const url = new URL(serverUrl);
+					if (!s.host) s.host = url.host;
+					if (!s.basePath) s.basePath = url.pathname;
+					if (!s.schemes || !s.schemes.length) {
+						s.schemes = [url.protocol.slice(0, -1)]; // remove trailing ':'
+					}
+				} else {
+					// Relative URL (e.g., '/v2')
+					if (!s.basePath) s.basePath = serverUrl;
+				}
+			} catch {
+				// If URL parsing fails, treat as relative path
+				if (!s.basePath) s.basePath = serverUrl;
+			}
+		}
+
+		// components.schemas -> definitions
+		if (spec.components?.schemas && !s.definitions) {
+			s.definitions = spec.components.schemas;
+		}
+
+		// components.securitySchemes -> securityDefinitions
+		if (spec.components?.securitySchemes && !s.securityDefinitions) {
+			s.securityDefinitions = spec.components.securitySchemes;
+		}
+	}
+
+	if (!s.basePath) s.basePath = '';
+	else if (s.basePath.endsWith('/'))
+		s.basePath = s.basePath.slice(0, -1);
 
 	if (src && /^https?:\/\//im.test(src)) {
 		const parts = src.split('/');
-		if (!spec.host) spec.host = parts[2];
-		if (!spec.schemes || !spec.schemes.length)
-			spec.schemes = [parts[0].slice(0, -1)];
+		if (!s.host) s.host = parts[2];
+		if (!s.schemes || !s.schemes.length)
+			s.schemes = [parts[0].slice(0, -1)];
 	} else {
-		if (!spec.host) spec.host = 'localhost';
-		if (!spec.schemes || !spec.schemes.length) spec.schemes = ['http'];
+		if (!s.host) s.host = 'localhost';
+		if (!s.schemes || !s.schemes.length) s.schemes = ['http'];
 	}
 
-	const s: any = spec;
 	if (!s.produces || !s.produces.length) {
 		s.accepts = ['application/json']; // give sensible default
 	} else {
@@ -80,11 +123,13 @@ function formatSpec(
 	delete s.consumes;
 	delete s.produces;
 
-	return <ApiSpec>expandRefs(spec, spec, options);
+	return <ApiSpec>expandRefs(s, s, options);
 }
 
 /**
  * Recursively expand internal references in the form `#/path/to/object`.
+ * Only expands refs to #/components/parameters/ - schemas ($refs to #/components/schemas/)
+ * are preserved for the type generator to handle.
  *
  * @param {object} data the object to search for and update refs
  * @param {object} lookup the object to clone refs from
@@ -106,9 +151,13 @@ export function expandRefs(
 			data.$ref &&
 			!(options.ignoreRefType && data.$ref.startsWith(options.ignoreRefType))
 		) {
-			const resolved = expandRef(data.$ref, lookup);
-			delete data.$ref;
-			data = Object.assign({}, resolved, data);
+			// Only expand refs that are NOT schema refs (schema refs are handled by type generator)
+			// This prevents circular reference issues when schemas reference each other
+			if (!data.$ref.startsWith('#/components/schemas/') && !data.$ref.startsWith('#/definitions/')) {
+				const resolved = expandRef(data.$ref, lookup);
+				delete data.$ref;
+				data = Object.assign({}, resolved, data);
+			}
 		}
 		dataCache.add(data);
 		for (let name in data) {


### PR DESCRIPTION
- Adds support for generating API clients from OpenAPI 3.0 specs
- Maintains backwards compatibility with Swagger 2.0 specs
- Converts OpenAPI 3.0 structures to internal format for code generation

### All related PRs (including this one):

- https://github.com/granodigital/ecom-api/pull/4190
- https://github.com/granodigital/openapi-client/pull/23
- https://github.com/granodigital/mygrano-auth/pull/1938
- https://github.com/granodigital/grano-nest-utils/pull/1470
- https://github.com/granodigital/ecom-storefront/pull/3355
- https://github.com/granodigital/ecom-admin/pull/2989