### PR TITLE
fix: [MTS-3020] derive content types from OpenAPI 3.0 requestBody/response content

### DIFF
--- a/dist/gen/js/genOperations.js
+++ b/dist/gen/js/genOperations.js
@@ -321,6 +321,13 @@ function renderOperationInfo(spec, op, options) {
     if (hasBody && op.contentTypes.length) {
         lines.push(`${support_1.SP}contentTypes: ['${op.contentTypes.join("','")}'],`);
     }
+    // Only emit `accepts` when it carries real signal (e.g. XML); JSON is the
+    // gateway default, so omitting it keeps JSON clients byte-identical.
+    if (op.accepts &&
+        op.accepts.length &&
+        !(op.accepts.length === 1 && op.accepts[0] === 'application/json')) {
+        lines.push(`${support_1.SP}accepts: ['${op.accepts.join("','")}'],`);
+    }
     lines.push(`${support_1.SP}method: '${op.method}'${op.security ? ',' : ''}`);
     if (op.security && op.security.length) {
         const secLines = renderSecurityInfo(op.security);

--- a/dist/spec/operations.js
+++ b/dist/spec/operations.js
@@ -58,6 +58,12 @@ function getPathOperation(method, pathInfo, spec) {
                 description: op.requestBody.description || '',
             });
         }
+        // OpenAPI 3.0 encodes the request media type(s) under requestBody.content
+        // (Swagger 2.0 used `consumes`). Propagate them so non-JSON bodies (e.g. XML)
+        // are not defaulted to application/json downstream.
+        const requestContentTypes = Object.keys(content || {});
+        if (requestContentTypes.length)
+            op.contentTypes = requestContentTypes;
         delete op.requestBody;
     }
     op.group = getOperationGroupName(op);
@@ -71,6 +77,14 @@ function getPathOperation(method, pathInfo, spec) {
         operation.accepts = operation.produces;
     delete operation.consumes;
     delete operation.produces;
+    // OpenAPI 3.0 encodes response media types under responses[code].content
+    // (Swagger 2.0 used `produces`). Derive the Accept header from the success
+    // responses so non-JSON responses (e.g. XML) are not defaulted to JSON.
+    if (!op.accepts || !op.accepts.length) {
+        const responseContentTypes = getResponseContentTypes(op.responses);
+        if (responseContentTypes.length)
+            op.accepts = responseContentTypes;
+    }
     if (!op.contentTypes || !op.contentTypes.length)
         op.contentTypes = spec.contentTypes.slice();
     if (!op.accepts || !op.accepts.length)
@@ -96,6 +110,21 @@ function getOperationResponses(op) {
         }
         return info;
     });
+}
+function getResponseContentTypes(responses) {
+    const types = [];
+    for (const res of responses || []) {
+        if (!res || !res.content)
+            continue;
+        // Only success responses inform the Accept header the client sends.
+        if (!/^2/.test(String(res.code)))
+            continue;
+        for (const type of Object.keys(res.content)) {
+            if (!types.includes(type))
+                types.push(type);
+        }
+    }
+    return types;
 }
 function getOperationSecurity(op, spec) {
     let security;

--- a/src/gen/js/genOperations.ts
+++ b/src/gen/js/genOperations.ts
@@ -411,6 +411,15 @@ function renderOperationInfo(
 	if (hasBody && op.contentTypes.length) {
 		lines.push(`${SP}contentTypes: ['${op.contentTypes.join("','")}'],`);
 	}
+	// Only emit `accepts` when it carries real signal (e.g. XML); JSON is the
+	// gateway default, so omitting it keeps JSON clients byte-identical.
+	if (
+		op.accepts &&
+		op.accepts.length &&
+		!(op.accepts.length === 1 && op.accepts[0] === 'application/json')
+	) {
+		lines.push(`${SP}accepts: ['${op.accepts.join("','")}'],`);
+	}
 	lines.push(`${SP}method: '${op.method}'${op.security ? ',' : ''}`);
 	if (op.security && op.security.length) {
 		const secLines = renderSecurityInfo(op.security);

--- a/src/spec/operations.ts
+++ b/src/spec/operations.ts
@@ -78,6 +78,11 @@ function getPathOperation(
 				description: op.requestBody.description || '',
 			});
 		}
+		// OpenAPI 3.0 encodes the request media type(s) under requestBody.content
+		// (Swagger 2.0 used `consumes`). Propagate them so non-JSON bodies (e.g. XML)
+		// are not defaulted to application/json downstream.
+		const requestContentTypes = Object.keys(content || {});
+		if (requestContentTypes.length) op.contentTypes = requestContentTypes;
 		delete op.requestBody;
 	}
 
@@ -91,6 +96,14 @@ function getPathOperation(
 	if (operation.produces) operation.accepts = operation.produces;
 	delete operation.consumes;
 	delete operation.produces;
+
+	// OpenAPI 3.0 encodes response media types under responses[code].content
+	// (Swagger 2.0 used `produces`). Derive the Accept header from the success
+	// responses so non-JSON responses (e.g. XML) are not defaulted to JSON.
+	if (!op.accepts || !op.accepts.length) {
+		const responseContentTypes = getResponseContentTypes(op.responses);
+		if (responseContentTypes.length) op.accepts = responseContentTypes;
+	}
 
 	if (!op.contentTypes || !op.contentTypes.length)
 		op.contentTypes = spec.contentTypes.slice();
@@ -119,6 +132,19 @@ function getOperationResponses(op: any): ApiOperationResponse[] {
 		}
 		return info;
 	});
+}
+
+function getResponseContentTypes(responses: any[]): string[] {
+	const types: string[] = [];
+	for (const res of responses || []) {
+		if (!res || !res.content) continue;
+		// Only success responses inform the Accept header the client sends.
+		if (!/^2/.test(String(res.code))) continue;
+		for (const type of Object.keys(res.content)) {
+			if (!types.includes(type)) types.push(type);
+		}
+	}
+	return types;
 }
 
 function getOperationSecurity(op: any, spec: any): ApiOperationSecurity[] {

--- a/test/openapi3.yml
+++ b/test/openapi3.yml
@@ -1,0 +1,59 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: Content Type Test
+paths:
+  /xml:
+    post:
+      operationId: xmlEcho
+      tags:
+        - ct
+      requestBody:
+        required: true
+        content:
+          application/xml:
+            schema:
+              type: string
+      responses:
+        '200':
+          description: ok
+          content:
+            application/xml:
+              schema:
+                type: string
+  /json:
+    post:
+      operationId: jsonCreate
+      tags:
+        - ct
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '201':
+          description: created
+          content:
+            application/json:
+              schema:
+                type: object
+  /mixed:
+    post:
+      operationId: jsonReqXmlResp
+      tags:
+        - ct
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: ok
+          content:
+            application/xml:
+              schema:
+                type: string

--- a/test/spec/operations.spec.ts
+++ b/test/spec/operations.spec.ts
@@ -24,4 +24,34 @@ describe('operations', () => {
 		const resDefault = listPets.responses.find((res) => res.code === 'default');
 		expect(resDefault).not.toBeFalsy();
 	});
+
+	describe('OpenAPI 3.0 content types', () => {
+		let operations: any[];
+		beforeAll(async () => {
+			const spec = await resolveSpec(`${__dirname}/../openapi3.yml`);
+			operations = getOperations(spec);
+		});
+
+		it('derives request contentTypes from requestBody.content (XML)', () => {
+			const op = operations.find((o) => o.id === 'xmlEcho');
+			expect(op.contentTypes).toEqual(['application/xml']);
+		});
+
+		it('derives accepts from the success response content (XML)', () => {
+			const op = operations.find((o) => o.id === 'xmlEcho');
+			expect(op.accepts).toEqual(['application/xml']);
+		});
+
+		it('keeps JSON request/response as application/json', () => {
+			const op = operations.find((o) => o.id === 'jsonCreate');
+			expect(op.contentTypes).toEqual(['application/json']);
+			expect(op.accepts).toEqual(['application/json']);
+		});
+
+		it('derives request and response content types independently', () => {
+			const op = operations.find((o) => o.id === 'jsonReqXmlResp');
+			expect(op.contentTypes).toEqual(['application/json']);
+			expect(op.accepts).toEqual(['application/xml']);
+		});
+	});
 });


### PR DESCRIPTION
## Problem

Clients generated from OpenAPI 3.0 specs send `application/json` for **every** endpoint, even ones the spec declares as XML (or any other media type).

Concretely: the cXML PunchOut Order Request tool in ecom-admin posts to `POST /v2/cxml/punchout`, which the spec declares as `application/xml`. The generated client instead sent `Content-Type: application/json` with the cXML `JSON.stringify`'d into a string. ecom-api's global `express.json()` parser then tried to `JSON.parse` the XML and returned a 400 (`Unexpected token '"', ""<?xml ver"... is not valid JSON`) before any cXML handler ran.

## Root cause

OpenAPI 3.0 carries request/response media types under `requestBody.content` and `responses[code].content`. The 3.0 support (added in "feat: add openapi 3.0 support") read those maps only to extract the JSON schema, and never set `op.contentTypes` / `op.accepts`. The only code paths that populate those are the Swagger 2.0 `consumes` / `produces` fields — absent in 3.0 — so every operation fell through to the `application/json` default in `spec.ts`.

## Fix

- `src/spec/operations.ts`: populate `contentTypes` from `requestBody.content` media types, and `accepts` from the success (2xx) response content media types.
- `src/gen/js/genOperations.ts`: emit `accepts` only when it's not the `application/json` default, so existing JSON clients regenerate byte-identically (no churn).

## Impact / blast radius

Consumers: **ecom-admin, ecom-storefront, ecom-order-synchronizer** (all on the same pin). On regeneration:
- **JSON endpoints** (the vast majority — 64 request / 166 response bodies in the current ecom-api spec): byte-identical output.
- **XML endpoints** (cXML: 2 request, 3 response bodies): corrected to `application/xml` — this is the fix.
- **`multipart/form-data`** (`uploadEditorTemplate`, 1 endpoint): flips to `multipart/form-data`. It is not called by application code in any of the three consumers (dead generated stub), so no runtime impact.

## Testing

- Added an OpenAPI 3.0 fixture (`test/openapi3.yml`) and 4 cases covering XML request/response derivation, a JSON control, and independent request/response types. Verified they fail against the unpatched parser and pass with the fix.
- Verified end-to-end by `npm link`-ing this branch into ecom-admin and running `npm run apigen:file`: `punchOutOperation` now generates `contentTypes: ['application/xml'], accepts: ['application/xml']`; JSON ops unchanged.

## Rollout

After merge, bump the `openapi-client` pin in ecom-admin, ecom-storefront, and ecom-order-synchronizer, regenerate their clients, and deploy. Worth a glance at each regen diff before deploying.
